### PR TITLE
adds an in-app update check flow for Wallpaper Switcher.Update checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   <img src="./assets/gifs/Settings_Demo.gif" alt="Settings window demo" width="350"/>
 
   - Configure hotkeys, startup behavior, and wallpaper switching mode
+  - Check whether a newer GitHub release is available
 
 ## System Requirements
 
@@ -69,6 +70,8 @@ Settings and hotkeys are stored outside the app folder, so updating normally doe
 1. Exit Wallpaper Switcher completely from the tray menu.
 2. Replace the old `WallpaperSwitcher.exe` or extracted package files with the new release.
 3. Launch the app again.
+
+You can use **Settings** > **Check for Updates** to see whether a newer GitHub release is available. If an update exists, Wallpaper Switcher can open the release page for you.
 
 If you moved the executable to a new folder and enabled **Launch at startup**, disable and re-enable that option in **Settings** so Windows stores the new executable path.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,6 +35,7 @@
   <img src="./assets/gifs/Settings_Demo.gif" alt="设置窗口演示" width="350"/>
 
   - 配置快捷键、开机自启和壁纸切换模式
+  - 检查 GitHub 上是否有新版本发布
 
 ## 系统要求
 
@@ -69,6 +70,8 @@ Wallpaper Switcher 是便携版软件，不需要传统安装程序。你可以�
 1. 从托盘菜单完全退出 Wallpaper Switcher
 2. 用新版 `WallpaperSwitcher.exe` 或新版完整包文件替换旧文件
 3. 重新启动程序
+
+你可以在 **设置** 中点击 **Check for Updates** 检查 GitHub 上是否有新版本。如果存在更新，Wallpaper Switcher 可以帮你打开对应的发布页面。
 
 如果你把程序移动到了新目录，并且启用了 **开机自启**，请在 **设置** 中先关闭再重新开启该选项，让 Windows 记录新的程序路径。
 

--- a/src/WallpaperSwitcher.Core/Updates/GitHubReleaseResponse.cs
+++ b/src/WallpaperSwitcher.Core/Updates/GitHubReleaseResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace WallpaperSwitcher.Core.Updates;
+
+internal sealed class GitHubReleaseResponse
+{
+    [JsonPropertyName("tag_name")]
+    public string? TagName { get; set; }
+
+    [JsonPropertyName("html_url")]
+    public string? HtmlUrl { get; set; }
+}

--- a/src/WallpaperSwitcher.Core/Updates/GitHubUpdateChecker.cs
+++ b/src/WallpaperSwitcher.Core/Updates/GitHubUpdateChecker.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
@@ -11,10 +13,12 @@ public sealed class GitHubUpdateChecker : IUpdateChecker
     private static readonly Uri DefaultLatestReleaseApiUri =
         new("https://api.github.com/repos/lorenzoyang/WallpaperSwitcher/releases/latest");
 
+    private static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(15);
     private static readonly HttpClient SharedHttpClient = new();
 
     private readonly HttpClient _httpClient;
     private readonly Uri _latestReleaseApiUri;
+    private readonly TimeSpan _requestTimeout;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GitHubUpdateChecker"/> class.
@@ -32,9 +36,20 @@ public sealed class GitHubUpdateChecker : IUpdateChecker
     }
 
     internal GitHubUpdateChecker(HttpClient httpClient, Uri latestReleaseApiUri)
+        : this(httpClient, latestReleaseApiUri, DefaultRequestTimeout)
+    {
+    }
+
+    internal GitHubUpdateChecker(HttpClient httpClient, Uri latestReleaseApiUri, TimeSpan requestTimeout)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _latestReleaseApiUri = latestReleaseApiUri ?? throw new ArgumentNullException(nameof(latestReleaseApiUri));
+        if (requestTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(requestTimeout), "The update check timeout must be positive.");
+        }
+
+        _requestTimeout = requestTimeout;
     }
 
     /// <inheritdoc/>
@@ -43,11 +58,15 @@ public sealed class GitHubUpdateChecker : IUpdateChecker
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(currentVersion);
+        using var timeoutCancellationTokenSource = new CancellationTokenSource(_requestTimeout);
+        using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCancellationTokenSource.Token);
 
         try
         {
             var normalizedCurrentVersion = NormalizeVersion(currentVersion);
-            var release = await GetLatestReleaseAsync(cancellationToken);
+            var release = await GetLatestReleaseAsync(linkedCancellationTokenSource.Token);
             var latestTagName = GetReleaseTagName(release.TagName);
             var latestVersion = ParseReleaseVersion(latestTagName);
             var releaseUri = ParseReleaseUri(release.HtmlUrl);
@@ -66,7 +85,7 @@ public sealed class GitHubUpdateChecker : IUpdateChecker
         {
             throw new UpdateCheckException("GitHub could not be reached.", exception);
         }
-        catch (TaskCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
         {
             throw new UpdateCheckException("The update check timed out.", exception);
         }
@@ -101,8 +120,7 @@ public sealed class GitHubUpdateChecker : IUpdateChecker
 
         if (!response.IsSuccessStatusCode)
         {
-            throw new UpdateCheckException(
-                $"GitHub returned HTTP {(int)response.StatusCode} ({response.ReasonPhrase}).");
+            throw new UpdateCheckException(CreateHttpErrorMessage(response));
         }
 
         await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
@@ -131,7 +149,12 @@ public sealed class GitHubUpdateChecker : IUpdateChecker
 
     private static Version ParseReleaseVersion(string tagName)
     {
-        var versionText = tagName.Trim().TrimStart('v', 'V');
+        var versionText = tagName.Trim();
+        if (versionText.Length > 0 && (versionText[0] == 'v' || versionText[0] == 'V'))
+        {
+            versionText = versionText[1..];
+        }
+
         if (!Version.TryParse(versionText, out var version))
         {
             throw new UpdateCheckException($"GitHub returned an unsupported release tag: {tagName}.");
@@ -142,11 +165,75 @@ public sealed class GitHubUpdateChecker : IUpdateChecker
 
     private static Uri ParseReleaseUri(string? htmlUrl)
     {
-        if (!Uri.TryCreate(htmlUrl, UriKind.Absolute, out var releaseUri))
+        if (!Uri.TryCreate(htmlUrl, UriKind.Absolute, out var releaseUri) ||
+            !IsTrustedGitHubReleaseUri(releaseUri))
         {
             throw new UpdateCheckException("GitHub did not return a valid release page URL.");
         }
 
         return releaseUri;
+    }
+
+    private static string CreateHttpErrorMessage(HttpResponseMessage response)
+    {
+        if (IsRateLimitResponse(response))
+        {
+            var retryAfter = GetRateLimitRetryAfter(response);
+            return retryAfter is null
+                ? "GitHub API rate limit was exceeded. Please try again later."
+                : $"GitHub API rate limit was exceeded. Please try again after {retryAfter}.";
+        }
+
+        return $"GitHub returned HTTP {(int)response.StatusCode} ({response.ReasonPhrase}).";
+    }
+
+    private static bool IsRateLimitResponse(HttpResponseMessage response)
+    {
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            return true;
+        }
+
+        return response.StatusCode == HttpStatusCode.Forbidden &&
+               response.Headers.TryGetValues("X-RateLimit-Remaining", out var values) &&
+               values.Any(value => string.Equals(value, "0", StringComparison.Ordinal));
+    }
+
+    private static string? GetRateLimitRetryAfter(HttpResponseMessage response)
+    {
+        if (response.Headers.RetryAfter?.Date is { } retryAfterDate)
+        {
+            return FormatUtc(retryAfterDate);
+        }
+
+        if (response.Headers.RetryAfter?.Delta is { } retryAfterDelta)
+        {
+            return FormatUtc(DateTimeOffset.UtcNow.Add(retryAfterDelta));
+        }
+
+        if (response.Headers.TryGetValues("X-RateLimit-Reset", out var values) &&
+            values.FirstOrDefault() is { } resetValue &&
+            long.TryParse(resetValue, CultureInfo.InvariantCulture, out var unixResetTime))
+        {
+            return FormatUtc(DateTimeOffset.FromUnixTimeSeconds(unixResetTime));
+        }
+
+        return null;
+    }
+
+    private static string FormatUtc(DateTimeOffset dateTimeOffset)
+    {
+        return dateTimeOffset
+            .ToUniversalTime()
+            .ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsTrustedGitHubReleaseUri(Uri releaseUri)
+    {
+        return releaseUri.Scheme == Uri.UriSchemeHttps &&
+               string.Equals(releaseUri.Host, "github.com", StringComparison.OrdinalIgnoreCase) &&
+               releaseUri.AbsolutePath.StartsWith(
+                   "/lorenzoyang/WallpaperSwitcher/releases/",
+                   StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/WallpaperSwitcher.Core/Updates/GitHubUpdateChecker.cs
+++ b/src/WallpaperSwitcher.Core/Updates/GitHubUpdateChecker.cs
@@ -1,0 +1,152 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace WallpaperSwitcher.Core.Updates;
+
+/// <summary>
+/// Checks GitHub Releases for the latest published Wallpaper Switcher version.
+/// </summary>
+public sealed class GitHubUpdateChecker : IUpdateChecker
+{
+    private static readonly Uri DefaultLatestReleaseApiUri =
+        new("https://api.github.com/repos/lorenzoyang/WallpaperSwitcher/releases/latest");
+
+    private static readonly HttpClient SharedHttpClient = new();
+
+    private readonly HttpClient _httpClient;
+    private readonly Uri _latestReleaseApiUri;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitHubUpdateChecker"/> class.
+    /// </summary>
+    public GitHubUpdateChecker() : this(SharedHttpClient)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitHubUpdateChecker"/> class.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client used to call the GitHub API.</param>
+    public GitHubUpdateChecker(HttpClient httpClient) : this(httpClient, DefaultLatestReleaseApiUri)
+    {
+    }
+
+    internal GitHubUpdateChecker(HttpClient httpClient, Uri latestReleaseApiUri)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _latestReleaseApiUri = latestReleaseApiUri ?? throw new ArgumentNullException(nameof(latestReleaseApiUri));
+    }
+
+    /// <inheritdoc/>
+    public async Task<UpdateCheckResult> CheckForUpdatesAsync(
+        Version currentVersion,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(currentVersion);
+
+        try
+        {
+            var normalizedCurrentVersion = NormalizeVersion(currentVersion);
+            var release = await GetLatestReleaseAsync(cancellationToken);
+            var latestTagName = GetReleaseTagName(release.TagName);
+            var latestVersion = ParseReleaseVersion(latestTagName);
+            var releaseUri = ParseReleaseUri(release.HtmlUrl);
+
+            return new UpdateCheckResult(
+                normalizedCurrentVersion,
+                latestVersion,
+                latestTagName,
+                releaseUri);
+        }
+        catch (UpdateCheckException)
+        {
+            throw;
+        }
+        catch (HttpRequestException exception)
+        {
+            throw new UpdateCheckException("GitHub could not be reached.", exception);
+        }
+        catch (TaskCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new UpdateCheckException("The update check timed out.", exception);
+        }
+        catch (JsonException exception)
+        {
+            throw new UpdateCheckException("GitHub returned an invalid release response.", exception);
+        }
+        catch (NotSupportedException exception)
+        {
+            throw new UpdateCheckException("GitHub returned an unsupported release response.", exception);
+        }
+    }
+
+    internal static Version NormalizeVersion(Version version)
+    {
+        return new Version(
+            version.Major,
+            Math.Max(version.Minor, 0),
+            Math.Max(version.Build, 0));
+    }
+
+    private async Task<GitHubReleaseResponse> GetLatestReleaseAsync(CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, _latestReleaseApiUri);
+        request.Headers.UserAgent.Add(new ProductInfoHeaderValue("WallpaperSwitcher", "1.0"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new UpdateCheckException(
+                $"GitHub returned HTTP {(int)response.StatusCode} ({response.ReasonPhrase}).");
+        }
+
+        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var release = await JsonSerializer.DeserializeAsync(
+            responseStream,
+            UpdateCheckJsonContext.Default.GitHubReleaseResponse,
+            cancellationToken);
+
+        if (release is null)
+        {
+            throw new UpdateCheckException("GitHub returned an empty release response.");
+        }
+
+        return release;
+    }
+
+    private static string GetReleaseTagName(string? tagName)
+    {
+        if (string.IsNullOrWhiteSpace(tagName))
+        {
+            throw new UpdateCheckException("GitHub did not return a release tag.");
+        }
+
+        return tagName.Trim();
+    }
+
+    private static Version ParseReleaseVersion(string tagName)
+    {
+        var versionText = tagName.Trim().TrimStart('v', 'V');
+        if (!Version.TryParse(versionText, out var version))
+        {
+            throw new UpdateCheckException($"GitHub returned an unsupported release tag: {tagName}.");
+        }
+
+        return NormalizeVersion(version);
+    }
+
+    private static Uri ParseReleaseUri(string? htmlUrl)
+    {
+        if (!Uri.TryCreate(htmlUrl, UriKind.Absolute, out var releaseUri))
+        {
+            throw new UpdateCheckException("GitHub did not return a valid release page URL.");
+        }
+
+        return releaseUri;
+    }
+}

--- a/src/WallpaperSwitcher.Core/Updates/IUpdateChecker.cs
+++ b/src/WallpaperSwitcher.Core/Updates/IUpdateChecker.cs
@@ -1,0 +1,17 @@
+namespace WallpaperSwitcher.Core.Updates;
+
+/// <summary>
+/// Checks whether a newer Wallpaper Switcher release is available.
+/// </summary>
+public interface IUpdateChecker
+{
+    /// <summary>
+    /// Compares the current application version against the latest available release.
+    /// </summary>
+    /// <param name="currentVersion">The version reported by the running application.</param>
+    /// <param name="cancellationToken">A token used to cancel the update check.</param>
+    /// <returns>The result of the update check.</returns>
+    Task<UpdateCheckResult> CheckForUpdatesAsync(
+        Version currentVersion,
+        CancellationToken cancellationToken = default);
+}

--- a/src/WallpaperSwitcher.Core/Updates/UpdateCheckException.cs
+++ b/src/WallpaperSwitcher.Core/Updates/UpdateCheckException.cs
@@ -1,0 +1,24 @@
+namespace WallpaperSwitcher.Core.Updates;
+
+/// <summary>
+/// Represents a controlled failure while checking for application updates.
+/// </summary>
+public sealed class UpdateCheckException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateCheckException"/> class.
+    /// </summary>
+    /// <param name="message">The failure message.</param>
+    public UpdateCheckException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateCheckException"/> class.
+    /// </summary>
+    /// <param name="message">The failure message.</param>
+    /// <param name="innerException">The original exception that caused the failure.</param>
+    public UpdateCheckException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/WallpaperSwitcher.Core/Updates/UpdateCheckJsonContext.cs
+++ b/src/WallpaperSwitcher.Core/Updates/UpdateCheckJsonContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace WallpaperSwitcher.Core.Updates;
+
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(GitHubReleaseResponse))]
+internal partial class UpdateCheckJsonContext : JsonSerializerContext
+{
+}

--- a/src/WallpaperSwitcher.Core/Updates/UpdateCheckResult.cs
+++ b/src/WallpaperSwitcher.Core/Updates/UpdateCheckResult.cs
@@ -1,0 +1,20 @@
+namespace WallpaperSwitcher.Core.Updates;
+
+/// <summary>
+/// Represents the result of comparing the current app version with the latest release version.
+/// </summary>
+/// <param name="CurrentVersion">The normalized current application version.</param>
+/// <param name="LatestVersion">The normalized latest release version.</param>
+/// <param name="LatestTagName">The release tag returned by the release provider.</param>
+/// <param name="ReleaseUri">The public release page URI.</param>
+public sealed record UpdateCheckResult(
+    Version CurrentVersion,
+    Version LatestVersion,
+    string LatestTagName,
+    Uri ReleaseUri)
+{
+    /// <summary>
+    /// Gets a value indicating whether the latest release is newer than the current version.
+    /// </summary>
+    public bool IsUpdateAvailable => LatestVersion.CompareTo(CurrentVersion) > 0;
+}

--- a/src/WallpaperSwitcher.Desktop/FormHelper.cs
+++ b/src/WallpaperSwitcher.Desktop/FormHelper.cs
@@ -51,6 +51,15 @@ internal static class FormHelper
         );
     }
 
+    public static void OpenUrl(Uri uri)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = uri.AbsoluteUri,
+            UseShellExecute = true
+        });
+    }
+
     public static void ShowFolderToolTipForComboBox(ToolTip toolTip, ComboBox? comboBox)
     {
         if (comboBox is { SelectedItem: not null })

--- a/src/WallpaperSwitcher.Desktop/SettingsForm.Designer.cs
+++ b/src/WallpaperSwitcher.Desktop/SettingsForm.Designer.cs
@@ -40,6 +40,7 @@ namespace WallpaperSwitcher.Desktop
             folderHkSaveButton = new Button();
             folderHkLabel = new Label();
             launchStartupCheckBox = new CheckBox();
+            checkForUpdatesButton = new Button();
             settingsFormOkButton = new Button();
             hotkeysGroupBox = new GroupBox();
             generalGroupBox = new GroupBox();
@@ -190,7 +191,24 @@ namespace WallpaperSwitcher.Desktop
             launchStartupCheckBox.Text = "Launch at startup";
             launchStartupCheckBox.UseVisualStyleBackColor = true;
             launchStartupCheckBox.CheckedChanged += launchStartupCheckBox_CheckedChanged;
-            // 
+            //
+            // checkForUpdatesButton
+            //
+            checkForUpdatesButton.BackColor = Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(227)))), ((int)(((byte)(229)))));
+            checkForUpdatesButton.FlatAppearance.BorderSize = 0;
+            checkForUpdatesButton.FlatAppearance.MouseDownBackColor = Color.FromArgb(((int)(((byte)(203)))), ((int)(((byte)(206)))), ((int)(((byte)(208)))));
+            checkForUpdatesButton.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(194)))), ((int)(((byte)(196)))), ((int)(((byte)(199)))));
+            checkForUpdatesButton.FlatStyle = FlatStyle.Flat;
+            checkForUpdatesButton.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Bold);
+            checkForUpdatesButton.ForeColor = Color.FromArgb(((int)(((byte)(52)))), ((int)(((byte)(58)))), ((int)(((byte)(64)))));
+            checkForUpdatesButton.Location = new Point(23, 65);
+            checkForUpdatesButton.Name = "checkForUpdatesButton";
+            checkForUpdatesButton.Size = new Size(160, 30);
+            checkForUpdatesButton.TabIndex = 13;
+            checkForUpdatesButton.Text = "Check for Updates";
+            checkForUpdatesButton.UseVisualStyleBackColor = false;
+            checkForUpdatesButton.Click += checkForUpdatesButton_Click;
+            //
             // settingsFormOkButton
             // 
             settingsFormOkButton.Anchor = ((AnchorStyles)((AnchorStyles.Bottom | AnchorStyles.Right)));
@@ -202,10 +220,10 @@ namespace WallpaperSwitcher.Desktop
             settingsFormOkButton.FlatStyle = FlatStyle.Flat;
             settingsFormOkButton.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Bold);
             settingsFormOkButton.ForeColor = Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(69)))), ((int)(((byte)(149)))));
-            settingsFormOkButton.Location = new Point(490, 275);
+            settingsFormOkButton.Location = new Point(490, 315);
             settingsFormOkButton.Name = "settingsFormOkButton";
             settingsFormOkButton.Size = new Size(90, 30);
-            settingsFormOkButton.TabIndex = 13;
+            settingsFormOkButton.TabIndex = 14;
             settingsFormOkButton.Text = "OK";
             settingsFormOkButton.UseVisualStyleBackColor = false;
             settingsFormOkButton.Click += settingsFormOkButton_Click;
@@ -235,11 +253,12 @@ namespace WallpaperSwitcher.Desktop
             // 
             generalGroupBox.Anchor = ((AnchorStyles)(((AnchorStyles.Top | AnchorStyles.Left)
            | AnchorStyles.Right)));
+            generalGroupBox.Controls.Add(checkForUpdatesButton);
             generalGroupBox.Controls.Add(launchStartupCheckBox);
             generalGroupBox.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Bold, GraphicsUnit.Point, ((byte)(0)));
             generalGroupBox.Location = new Point(15, 180);
             generalGroupBox.Name = "generalGroupBox";
-            generalGroupBox.Size = new Size(565, 75);
+            generalGroupBox.Size = new Size(565, 115);
             generalGroupBox.TabIndex = 15;
             generalGroupBox.TabStop = false;
             generalGroupBox.Text = "General";
@@ -254,14 +273,14 @@ namespace WallpaperSwitcher.Desktop
             mainPanel.Location = new Point(0, 0);
             mainPanel.Name = "mainPanel";
             mainPanel.Padding = new Padding(12);
-            mainPanel.Size = new Size(594, 321);
+            mainPanel.Size = new Size(594, 361);
             mainPanel.TabIndex = 16;
             // 
             // SettingsForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(594, 321);
+            ClientSize = new Size(594, 361);
             Controls.Add(mainPanel);
             Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
             FormBorderStyle = FormBorderStyle.FixedDialog;
@@ -294,6 +313,7 @@ namespace WallpaperSwitcher.Desktop
         private Button folderHkSaveButton;
         private Label folderHkLabel;
         private CheckBox launchStartupCheckBox;
+        private Button checkForUpdatesButton;
         private Button settingsFormOkButton;
         private GroupBox hotkeysGroupBox;
         private GroupBox generalGroupBox;

--- a/src/WallpaperSwitcher.Desktop/SettingsForm.cs
+++ b/src/WallpaperSwitcher.Desktop/SettingsForm.cs
@@ -1,6 +1,7 @@
 using WallpaperSwitcher.Core;
 using WallpaperSwitcher.Core.GlobalHotkey;
 using WallpaperSwitcher.Core.Persistence;
+using WallpaperSwitcher.Core.Updates;
 
 namespace WallpaperSwitcher.Desktop;
 
@@ -9,9 +10,13 @@ namespace WallpaperSwitcher.Desktop;
 /// </summary>
 public partial class SettingsForm : Form
 {
+    private const string CheckForUpdatesButtonDefaultText = "Check for Updates";
+    private const string CheckForUpdatesButtonBusyText = "Checking...";
+
     private readonly HotkeyService _hotkeyService;
     private readonly IAppSettingsStorage _appSettingsStorage;
     private readonly AppSettings _appSettings;
+    private readonly IUpdateChecker _updateChecker;
 
     // Caches folder hotkeys while the dialog is open so combo-box changes can update quickly.
     private readonly Dictionary<string, HotkeyInfo?> _folderHotkeys;
@@ -27,13 +32,15 @@ public partial class SettingsForm : Form
         HotkeyService hotkeyService,
         List<string> folders,
         IAppSettingsStorage appSettingsStorage,
-        AppSettings appSettings)
+        AppSettings appSettings,
+        IUpdateChecker? updateChecker = null)
     {
         InitializeComponent();
 
         _hotkeyService = hotkeyService;
         _appSettingsStorage = appSettingsStorage;
         _appSettings = appSettings;
+        _updateChecker = updateChecker ?? new GitHubUpdateChecker();
         _folderHotkeys = folders.ToDictionary(folder => folder, HotkeyInfo? (_) => null);
     }
 
@@ -202,6 +209,98 @@ public partial class SettingsForm : Form
     private void settingsFormOkButton_Click(object sender, EventArgs e)
     {
         DialogResult = DialogResult.OK;
+    }
+
+    private async void checkForUpdatesButton_Click(object sender, EventArgs e)
+    {
+        await CheckForUpdatesAsync();
+    }
+
+    private async Task CheckForUpdatesAsync()
+    {
+        SetUpdateCheckInProgress(true);
+
+        try
+        {
+            var result = await _updateChecker.CheckForUpdatesAsync(GetCurrentApplicationVersion());
+            if (result.IsUpdateAvailable)
+            {
+                ShowUpdateAvailableMessage(result);
+                return;
+            }
+
+            FormHelper.ShowSuccessMessage(
+                $"You are using the latest version.\n\nCurrent version: {FormatVersion(result.CurrentVersion)}",
+                "No Updates Found"
+            );
+        }
+        catch (UpdateCheckException exception)
+        {
+            FormHelper.ShowWarningMessage(
+                $"Unable to check for updates: {exception.Message}\n\n" +
+                "Please check your internet connection and try again.",
+                "Update Check Failed"
+            );
+        }
+        finally
+        {
+            SetUpdateCheckInProgress(false);
+        }
+    }
+
+    private void ShowUpdateAvailableMessage(UpdateCheckResult result)
+    {
+        var dialogResult = MessageBox.Show(
+            this,
+            "A new version of Wallpaper Switcher is available.\n\n" +
+            $"Current version: {FormatVersion(result.CurrentVersion)}\n" +
+            $"Latest version: {FormatVersion(result.LatestVersion)}\n\n" +
+            "Open the GitHub release page?",
+            "Update Available",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Information
+        );
+
+        if (dialogResult != DialogResult.Yes)
+        {
+            return;
+        }
+
+        try
+        {
+            FormHelper.OpenUrl(result.ReleaseUri);
+        }
+        catch (Exception exception)
+        {
+            FormHelper.ShowWarningMessage(
+                $"Unable to open the release page: {exception.Message}",
+                "Open Release Page Failed"
+            );
+        }
+    }
+
+    private void SetUpdateCheckInProgress(bool isChecking)
+    {
+        if (isChecking)
+        {
+            // Move focus before disabling the clicked button so WinForms does not select the hotkey textbox.
+            settingsFormOkButton.Focus();
+        }
+
+        checkForUpdatesButton.Enabled = !isChecking;
+        checkForUpdatesButton.Text = isChecking
+            ? CheckForUpdatesButtonBusyText
+            : CheckForUpdatesButtonDefaultText;
+    }
+
+    private static Version GetCurrentApplicationVersion()
+    {
+        return typeof(SettingsForm).Assembly.GetName().Version ?? new Version(0, 0, 0);
+    }
+
+    private static string FormatVersion(Version version)
+    {
+        return $"{version.Major}.{Math.Max(version.Minor, 0)}.{Math.Max(version.Build, 0)}";
     }
 
     private void launchStartupCheckBox_CheckedChanged(object? sender, EventArgs e)

--- a/src/WallpaperSwitcher.Desktop/SettingsForm.cs
+++ b/src/WallpaperSwitcher.Desktop/SettingsForm.cs
@@ -17,6 +17,8 @@ public partial class SettingsForm : Form
     private readonly IAppSettingsStorage _appSettingsStorage;
     private readonly AppSettings _appSettings;
     private readonly IUpdateChecker _updateChecker;
+    private CancellationTokenSource? _updateCheckCancellationTokenSource;
+    private bool _isClosing;
 
     // Caches folder hotkeys while the dialog is open so combo-box changes can update quickly.
     private readonly Dictionary<string, HotkeyInfo?> _folderHotkeys;
@@ -121,6 +123,13 @@ public partial class SettingsForm : Form
         LoadInitialSettings();
     }
 
+    protected override void OnFormClosing(FormClosingEventArgs e)
+    {
+        _isClosing = true;
+        _updateCheckCancellationTokenSource?.Cancel();
+        base.OnFormClosing(e);
+    }
+
     private void nextWallpaperHkModifyButton_Click(object sender, EventArgs e)
     {
         OriginalValue = nextWallpaperHkTextBox.Text;
@@ -219,10 +228,14 @@ public partial class SettingsForm : Form
     private async Task CheckForUpdatesAsync()
     {
         SetUpdateCheckInProgress(true);
+        using var updateCheckCancellationTokenSource = new CancellationTokenSource();
+        _updateCheckCancellationTokenSource = updateCheckCancellationTokenSource;
 
         try
         {
-            var result = await _updateChecker.CheckForUpdatesAsync(GetCurrentApplicationVersion());
+            var result = await _updateChecker.CheckForUpdatesAsync(
+                GetCurrentApplicationVersion(),
+                updateCheckCancellationTokenSource.Token);
             if (result.IsUpdateAvailable)
             {
                 ShowUpdateAvailableMessage(result);
@@ -234,6 +247,9 @@ public partial class SettingsForm : Form
                 "No Updates Found"
             );
         }
+        catch (OperationCanceledException) when (updateCheckCancellationTokenSource.IsCancellationRequested)
+        {
+        }
         catch (UpdateCheckException exception)
         {
             FormHelper.ShowWarningMessage(
@@ -244,7 +260,15 @@ public partial class SettingsForm : Form
         }
         finally
         {
-            SetUpdateCheckInProgress(false);
+            if (ReferenceEquals(_updateCheckCancellationTokenSource, updateCheckCancellationTokenSource))
+            {
+                _updateCheckCancellationTokenSource = null;
+            }
+
+            if (!_isClosing && !IsDisposed && !Disposing)
+            {
+                SetUpdateCheckInProgress(false);
+            }
         }
     }
 

--- a/src/WallpaperSwitcher.Desktop/WallpaperSwitcher.Desktop.csproj
+++ b/src/WallpaperSwitcher.Desktop/WallpaperSwitcher.Desktop.csproj
@@ -20,6 +20,7 @@
         <AssemblyName>WallpaperSwitcher</AssemblyName>
         <Company>lorenzoyang</Company>
         <Product>WallpaperSwitcher</Product>
+        <Version>3.0.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/WallpaperSwitcher.Core.Tests/Updates/GitHubUpdateCheckerTests.cs
+++ b/tests/WallpaperSwitcher.Core.Tests/Updates/GitHubUpdateCheckerTests.cs
@@ -5,6 +5,9 @@ namespace WallpaperSwitcher.Core.Tests.Updates;
 
 public class GitHubUpdateCheckerTests
 {
+    private static readonly Uri LatestReleaseApiUri =
+        new("https://api.github.com/repos/lorenzoyang/WallpaperSwitcher/releases/latest");
+
     [Test]
     public async Task CheckForUpdatesAsync_WhenLatestVersionIsNewer_ReturnsUpdateAvailable()
     {
@@ -73,6 +76,26 @@ public class GitHubUpdateCheckerTests
     }
 
     [Test]
+    public void CheckForUpdatesAsync_WhenGitHubRateLimitIsExceeded_ThrowsFriendlyUpdateCheckException()
+    {
+        var checker = CreateChecker(
+            "Rate limit exceeded",
+            HttpStatusCode.Forbidden,
+            configureResponse: response =>
+            {
+                response.Headers.TryAddWithoutValidation("X-RateLimit-Remaining", "0");
+                response.Headers.TryAddWithoutValidation("X-RateLimit-Reset", "0");
+            });
+
+        var exception = Assert.ThrowsAsync<UpdateCheckException>(
+            async () => await checker.CheckForUpdatesAsync(new Version(3, 0, 1)));
+
+        Assert.That(
+            exception?.Message,
+            Does.Contain("rate limit").And.Contain("1970-01-01 00:00:00 UTC"));
+    }
+
+    [Test]
     public void CheckForUpdatesAsync_WhenGitHubReturnsInvalidJson_ThrowsUpdateCheckException()
     {
         var checker = CreateChecker("{ invalid json");
@@ -111,6 +134,61 @@ public class GitHubUpdateCheckerTests
     }
 
     [Test]
+    public void CheckForUpdatesAsync_WhenReleaseTagHasMoreThanOneVPrefix_ThrowsUpdateCheckException()
+    {
+        var checker = CreateChecker("""
+                                    {
+                                      "tag_name": "vv3.0.2",
+                                      "html_url": "https://github.com/lorenzoyang/WallpaperSwitcher/releases/tag/vv3.0.2"
+                                    }
+                                    """);
+
+        var exception = Assert.ThrowsAsync<UpdateCheckException>(
+            async () => await checker.CheckForUpdatesAsync(new Version(3, 0, 1)));
+
+        Assert.That(exception?.Message, Does.Contain("unsupported release tag"));
+    }
+
+    [Test]
+    public void CheckForUpdatesAsync_WhenReleaseUrlIsNotTrustedGitHubUrl_ThrowsUpdateCheckException()
+    {
+        var checker = CreateChecker("""
+                                    {
+                                      "tag_name": "v3.0.2",
+                                      "html_url": "https://example.com/lorenzoyang/WallpaperSwitcher/releases/tag/v3.0.2"
+                                    }
+                                    """);
+
+        var exception = Assert.ThrowsAsync<UpdateCheckException>(
+            async () => await checker.CheckForUpdatesAsync(new Version(3, 0, 1)));
+
+        Assert.That(exception?.Message, Does.Contain("valid release page URL"));
+    }
+
+    [Test]
+    public void CheckForUpdatesAsync_WhenRequestTimesOut_ThrowsUpdateCheckException()
+    {
+        var handler = new StubHttpMessageHandler(async (_, cancellationToken) =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+        });
+
+        var checker = new GitHubUpdateChecker(
+            new HttpClient(handler),
+            LatestReleaseApiUri,
+            TimeSpan.FromMilliseconds(10));
+
+        var exception = Assert.ThrowsAsync<UpdateCheckException>(
+            async () => await checker.CheckForUpdatesAsync(new Version(3, 0, 1)));
+
+        Assert.That(exception?.Message, Does.Contain("timed out"));
+    }
+
+    [Test]
     public async Task CheckForUpdatesAsync_SendsGitHubHeaders()
     {
         HttpRequestMessage? capturedRequest = null;
@@ -135,39 +213,43 @@ public class GitHubUpdateCheckerTests
     private static GitHubUpdateChecker CreateChecker(
         string content,
         HttpStatusCode statusCode = HttpStatusCode.OK,
-        Action<HttpRequestMessage>? onRequest = null)
+        Action<HttpRequestMessage>? onRequest = null,
+        Action<HttpResponseMessage>? configureResponse = null)
     {
-        var handler = new StubHttpMessageHandler(request =>
+        var handler = new StubHttpMessageHandler((request, _) =>
         {
             onRequest?.Invoke(request);
-            return new HttpResponseMessage(statusCode)
+            var response = new HttpResponseMessage(statusCode)
             {
                 Content = new StringContent(content)
             };
+            configureResponse?.Invoke(response);
+
+            return Task.FromResult(response);
         });
 
         return new GitHubUpdateChecker(
             new HttpClient(handler),
-            new Uri("https://api.github.com/repos/lorenzoyang/WallpaperSwitcher/releases/latest"));
+            LatestReleaseApiUri);
     }
 
     private static GitHubUpdateChecker CreateThrowingChecker(Exception exception)
     {
-        var handler = new StubHttpMessageHandler(_ => throw exception);
+        var handler = new StubHttpMessageHandler((_, _) => throw exception);
 
         return new GitHubUpdateChecker(
             new HttpClient(handler),
-            new Uri("https://api.github.com/repos/lorenzoyang/WallpaperSwitcher/releases/latest"));
+            LatestReleaseApiUri);
     }
 
     private sealed class StubHttpMessageHandler(
-        Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseFactory) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            return Task.FromResult(responseFactory(request));
+            return responseFactory(request, cancellationToken);
         }
     }
 }

--- a/tests/WallpaperSwitcher.Core.Tests/Updates/GitHubUpdateCheckerTests.cs
+++ b/tests/WallpaperSwitcher.Core.Tests/Updates/GitHubUpdateCheckerTests.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using WallpaperSwitcher.Core.Updates;
+
+namespace WallpaperSwitcher.Core.Tests.Updates;
+
+public class GitHubUpdateCheckerTests
+{
+    [Test]
+    public async Task CheckForUpdatesAsync_WhenLatestVersionIsNewer_ReturnsUpdateAvailable()
+    {
+        var checker = CreateChecker("""
+                                    {
+                                      "tag_name": "v3.0.2",
+                                      "html_url": "https://github.com/lorenzoyang/WallpaperSwitcher/releases/tag/v3.0.2"
+                                    }
+                                    """);
+
+        var result = await checker.CheckForUpdatesAsync(new Version(3, 0, 1));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsUpdateAvailable, Is.True);
+            Assert.That(result.CurrentVersion, Is.EqualTo(new Version(3, 0, 1)));
+            Assert.That(result.LatestVersion, Is.EqualTo(new Version(3, 0, 2)));
+            Assert.That(result.LatestTagName, Is.EqualTo("v3.0.2"));
+        }
+    }
+
+    [Test]
+    public async Task CheckForUpdatesAsync_WhenVersionsAreEqual_IgnoresCurrentVersionRevision()
+    {
+        var checker = CreateChecker("""
+                                    {
+                                      "tag_name": "v3.0.1",
+                                      "html_url": "https://github.com/lorenzoyang/WallpaperSwitcher/releases/tag/v3.0.1"
+                                    }
+                                    """);
+
+        var result = await checker.CheckForUpdatesAsync(new Version(3, 0, 1, 0));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsUpdateAvailable, Is.False);
+            Assert.That(result.CurrentVersion, Is.EqualTo(new Version(3, 0, 1)));
+            Assert.That(result.LatestVersion, Is.EqualTo(new Version(3, 0, 1)));
+        }
+    }
+
+    [Test]
+    public async Task CheckForUpdatesAsync_WhenLatestVersionIsOlder_ReturnsNoUpdate()
+    {
+        var checker = CreateChecker("""
+                                    {
+                                      "tag_name": "v3.0.0",
+                                      "html_url": "https://github.com/lorenzoyang/WallpaperSwitcher/releases/tag/v3.0.0"
+                                    }
+                                    """);
+
+        var result = await checker.CheckForUpdatesAsync(new Version(3, 0, 1));
+
+        Assert.That(result.IsUpdateAvailable, Is.False);
+    }
+
+    [Test]
+    public void CheckForUpdatesAsync_WhenGitHubReturnsHttpError_ThrowsUpdateCheckException()
+    {
+        var checker = CreateChecker("Not found", HttpStatusCode.NotFound);
+
+        var exception = Assert.ThrowsAsync<UpdateCheckException>(
+            async () => await checker.CheckForUpdatesAsync(new Version(3, 0, 1)));
+
+        Assert.That(exception?.Message, Does.Contain("HTTP 404"));
+    }
+
+    [Test]
+    public void CheckForUpdatesAsync_WhenGitHubReturnsInvalidJson_ThrowsUpdateCheckException()
+    {
+        var checker = CreateChecker("{ invalid json");
+
+        var exception = Assert.ThrowsAsync<UpdateCheckException>(
+            async () => await checker.CheckForUpdatesAsync(new Version(3, 0, 1)));
+
+        Assert.That(exception?.Message, Does.Contain("invalid release response"));
+    }
+
+    [Test]
+    public void CheckForUpdatesAsync_WhenGitHubCannotBeReached_ThrowsUpdateCheckException()
+    {
+        var checker = CreateThrowingChecker(new HttpRequestException("Network unavailable"));
+
+        var exception = Assert.ThrowsAsync<UpdateCheckException>(
+            async () => await checker.CheckForUpdatesAsync(new Version(3, 0, 1)));
+
+        Assert.That(exception?.Message, Does.Contain("could not be reached"));
+    }
+
+    [Test]
+    public void CheckForUpdatesAsync_WhenGitHubReturnsInvalidReleaseTag_ThrowsUpdateCheckException()
+    {
+        var checker = CreateChecker("""
+                                    {
+                                      "tag_name": "latest",
+                                      "html_url": "https://github.com/lorenzoyang/WallpaperSwitcher/releases/tag/latest"
+                                    }
+                                    """);
+
+        var exception = Assert.ThrowsAsync<UpdateCheckException>(
+            async () => await checker.CheckForUpdatesAsync(new Version(3, 0, 1)));
+
+        Assert.That(exception?.Message, Does.Contain("unsupported release tag"));
+    }
+
+    [Test]
+    public async Task CheckForUpdatesAsync_SendsGitHubHeaders()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        var checker = CreateChecker("""
+                                    {
+                                      "tag_name": "v3.0.1",
+                                      "html_url": "https://github.com/lorenzoyang/WallpaperSwitcher/releases/tag/v3.0.1"
+                                    }
+                                    """, onRequest: request => capturedRequest = request);
+
+        _ = await checker.CheckForUpdatesAsync(new Version(3, 0, 1));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(capturedRequest?.Headers.UserAgent.ToString(), Does.Contain("WallpaperSwitcher"));
+            Assert.That(
+                capturedRequest?.Headers.Accept.Select(header => header.MediaType),
+                Does.Contain("application/vnd.github+json"));
+        }
+    }
+
+    private static GitHubUpdateChecker CreateChecker(
+        string content,
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        Action<HttpRequestMessage>? onRequest = null)
+    {
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            onRequest?.Invoke(request);
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content)
+            };
+        });
+
+        return new GitHubUpdateChecker(
+            new HttpClient(handler),
+            new Uri("https://api.github.com/repos/lorenzoyang/WallpaperSwitcher/releases/latest"));
+    }
+
+    private static GitHubUpdateChecker CreateThrowingChecker(Exception exception)
+    {
+        var handler = new StubHttpMessageHandler(_ => throw exception);
+
+        return new GitHubUpdateChecker(
+            new HttpClient(handler),
+            new Uri("https://api.github.com/repos/lorenzoyang/WallpaperSwitcher/releases/latest"));
+    }
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+}


### PR DESCRIPTION
Users can now open **Settings** and click **Check for Updates** to compare the running app version against the latest GitHub release. If a newer release is available, the app shows the current/latest versions and can open the GitHub release page directly.

## Changes

- Added a GitHub Releases-based update checker in the Core project.
- Added update check result, exception, JSON context, and release response types.
- Added a **Check for Updates** button to the Settings dialog.
- Added UI handling for update available, no update found, request failure, and release page opening.
- Added cancellation support so an in-progress update check is cancelled when the Settings window closes.
- Added a request timeout and clearer GitHub API rate-limit messages.
- Validates release URLs to ensure they point to the trusted GitHub releases path.
- Updated English and Chinese README files with the new update check behavior.
- Added unit tests for version comparison, invalid GitHub responses, HTTP errors, rate limits, timeout handling, trusted URL validation, and request headers.