### PR TITLE
Fix startup crash when saved hotkey cannot be registered

### DIFF
--- a/src/WallpaperSwitcher.Core/GlobalHotkey/HotkeyLoadFailure.cs
+++ b/src/WallpaperSwitcher.Core/GlobalHotkey/HotkeyLoadFailure.cs
@@ -1,0 +1,8 @@
+namespace WallpaperSwitcher.Core.GlobalHotkey;
+
+/// <summary>
+/// Describes a hotkey that could not be registered while loading persisted settings.
+/// </summary>
+/// <param name="HotkeyInfo">The persisted hotkey that failed to load.</param>
+/// <param name="ErrorMessage">The registration error for the hotkey.</param>
+public sealed record HotkeyLoadFailure(HotkeyInfo HotkeyInfo, string ErrorMessage);

--- a/src/WallpaperSwitcher.Core/GlobalHotkey/HotkeyLoadResult.cs
+++ b/src/WallpaperSwitcher.Core/GlobalHotkey/HotkeyLoadResult.cs
@@ -1,0 +1,18 @@
+namespace WallpaperSwitcher.Core.GlobalHotkey;
+
+/// <summary>
+/// Reports non-fatal failures that occurred while loading persisted hotkeys.
+/// </summary>
+/// <param name="Failures">The hotkeys that were skipped during startup registration.</param>
+public sealed record HotkeyLoadResult(IReadOnlyList<HotkeyLoadFailure> Failures)
+{
+    /// <summary>
+    /// Gets an empty successful load result.
+    /// </summary>
+    public static HotkeyLoadResult Success { get; } = new(Array.Empty<HotkeyLoadFailure>());
+
+    /// <summary>
+    /// Gets a value indicating whether any persisted hotkeys were skipped.
+    /// </summary>
+    public bool HasFailures => Failures.Count > 0;
+}

--- a/src/WallpaperSwitcher.Core/GlobalHotkey/HotkeyService.cs
+++ b/src/WallpaperSwitcher.Core/GlobalHotkey/HotkeyService.cs
@@ -316,48 +316,118 @@ public sealed class HotkeyService : IDisposable
 
     /// <summary>
     /// Loads hotkeys asynchronously from persistent storage and registers them.
-    /// If no hotkeys are found, a default hotkey is registered and saved.
+    /// If no storage file exists, a default hotkey is registered and saved.
     /// </summary>
-    public async Task LoadHotkeysAsync()
+    public async Task<HotkeyLoadResult> LoadHotkeysAsync()
     {
         ThrowIfDisposed();
 
-        if (RegisterLoadedHotkeys((await _hotkeyStorage.LoadAsync()).ToArray()))
+        var shouldCreateDefaultHotkey = !_hotkeyStorage.Exists;
+        var registrationResult = RegisterLoadedHotkeys(
+            (await _hotkeyStorage.LoadAsync()).ToArray(),
+            shouldCreateDefaultHotkey
+        );
+
+        if (registrationResult.ShouldSave)
         {
             await _hotkeyStorage.SaveAsync(GetHotkeySnapshot());
         }
+
+        return registrationResult.LoadResult;
     }
 
     /// <summary>
     /// Loads hotkeys from persistent storage and registers them.
-    /// If no hotkeys are found, a default hotkey is registered and saved.
+    /// If no storage file exists, a default hotkey is registered and saved.
     /// </summary>
-    public void LoadHotkeys()
+    public HotkeyLoadResult LoadHotkeys()
     {
         ThrowIfDisposed();
 
-        if (RegisterLoadedHotkeys(_hotkeyStorage.Load().ToArray()))
+        var shouldCreateDefaultHotkey = !_hotkeyStorage.Exists;
+        var registrationResult = RegisterLoadedHotkeys(
+            _hotkeyStorage.Load().ToArray(),
+            shouldCreateDefaultHotkey
+        );
+
+        if (registrationResult.ShouldSave)
         {
             _hotkeyStorage.Save(GetHotkeySnapshot());
         }
+
+        return registrationResult.LoadResult;
     }
 
-    private bool RegisterLoadedHotkeys(IReadOnlyCollection<HotkeyInfo> hotkeyInfos)
+    private LoadedHotkeysRegistrationResult RegisterLoadedHotkeys(
+        IReadOnlyCollection<HotkeyInfo> hotkeyInfos,
+        bool shouldCreateDefaultHotkey)
     {
-        // First launch: create the default "Next Wallpaper" binding and let the caller persist it.
+        var failures = new List<HotkeyLoadFailure>();
+        var shouldSave = false;
+
         if (hotkeyInfos.Count == 0)
         {
-            _ = RegisterHotkey(Default.NextWallpaperHotkeyString, Default.NextWallpaperHotkeyName);
+            if (shouldCreateDefaultHotkey)
+            {
+                var defaultHotkey = CreateDefaultHotkeyInfo();
+                shouldSave = true;
+                _ = TryRegisterLoadedHotkey(defaultHotkey, failures);
+            }
+
+            return CreateLoadedHotkeysRegistrationResult(failures, shouldSave);
+        }
+
+        foreach (var hotkeyInfo in hotkeyInfos)
+        {
+            if (!TryRegisterLoadedHotkey(hotkeyInfo, failures))
+            {
+                // Re-save the active hotkey to clear the failed one from storage
+                shouldSave = true;
+            }
+        }
+
+        return CreateLoadedHotkeysRegistrationResult(failures, shouldSave);
+    }
+
+    private bool TryRegisterLoadedHotkey(HotkeyInfo hotkeyInfo, ICollection<HotkeyLoadFailure> failures)
+    {
+        try
+        {
+            _ = RegisterHotkey(hotkeyInfo.Hotkey, hotkeyInfo.Name, hotkeyInfo.Id);
             return true;
         }
-
-        foreach (var (id, hotkey, name) in hotkeyInfos)
+        catch (HotkeyBindingException exception)
         {
-            _ = RegisterHotkey(hotkey, name, id);
+            failures.Add(new HotkeyLoadFailure(hotkeyInfo, exception.Message));
+            return false;
         }
-
-        return false;
+        catch (HotkeyDuplicateBindingException exception)
+        {
+            failures.Add(new HotkeyLoadFailure(hotkeyInfo, exception.Message));
+            return false;
+        }
     }
+
+    private HotkeyInfo CreateDefaultHotkeyInfo()
+    {
+        return CreateHotkeyInfo(
+            NextHotkeyId,
+            ParseHotkeyOrThrow(Default.NextWallpaperHotkeyString),
+            Default.NextWallpaperHotkeyName
+        );
+    }
+
+    private static LoadedHotkeysRegistrationResult CreateLoadedHotkeysRegistrationResult(
+        IReadOnlyList<HotkeyLoadFailure> failures,
+        bool shouldSave)
+    {
+        return new LoadedHotkeysRegistrationResult(
+            failures.Count == 0 ? HotkeyLoadResult.Success : new HotkeyLoadResult(failures.ToArray()),
+            shouldSave
+        );
+    }
+
+    private sealed record LoadedHotkeysRegistrationResult(HotkeyLoadResult LoadResult, bool ShouldSave);
 
     /// <summary>
     /// Saves the currently registered hotkeys asynchronously to persistent storage.

--- a/src/WallpaperSwitcher.Core/Persistence/IHotkeyStorage.cs
+++ b/src/WallpaperSwitcher.Core/Persistence/IHotkeyStorage.cs
@@ -8,6 +8,11 @@ namespace WallpaperSwitcher.Core.Persistence;
 public interface IHotkeyStorage
 {
     /// <summary>
+    /// Gets a value indicating whether the backing storage already exists.
+    /// </summary>
+    bool Exists { get; }
+
+    /// <summary>
     /// Asynchronously loads all stored global hotkey configurations.
     /// </summary>
     /// <returns>

--- a/src/WallpaperSwitcher.Core/Persistence/JsonHotkeyStorage.cs
+++ b/src/WallpaperSwitcher.Core/Persistence/JsonHotkeyStorage.cs
@@ -20,6 +20,9 @@ public sealed class JsonHotkeyStorage : IHotkeyStorage
     /// </summary>
     public string Location { get; }
 
+    /// <inheritdoc/>
+    public bool Exists => File.Exists(Location);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonHotkeyStorage"/> class
     /// using the default file storage location.

--- a/src/WallpaperSwitcher.Desktop/MainForm.Settings.cs
+++ b/src/WallpaperSwitcher.Desktop/MainForm.Settings.cs
@@ -13,7 +13,7 @@ public partial class MainForm
         }
 
         PopulateComponentsFromInitialSettings();
-        await _hotkeyService.LoadHotkeysAsync();
+        ShowHotkeyLoadWarning(await _hotkeyService.LoadHotkeysAsync());
     }
 
     private void LoadInitialSettings()
@@ -24,7 +24,28 @@ public partial class MainForm
         }
 
         PopulateComponentsFromInitialSettings();
-        _hotkeyService.LoadHotkeys();
+        ShowHotkeyLoadWarning(_hotkeyService.LoadHotkeys());
+    }
+
+    private static void ShowHotkeyLoadWarning(HotkeyLoadResult result)
+    {
+        if (!result.HasFailures)
+        {
+            return;
+        }
+
+        var failedHotkeys = string.Join(
+            Environment.NewLine,
+            result.Failures.Select(failure =>
+                $"- {failure.HotkeyInfo.Name}: {failure.HotkeyInfo.Hotkey}")
+        );
+
+        FormHelper.ShowWarningMessage(
+            "Some saved hotkeys could not be registered and have been disabled:\n\n" +
+            $"{failedHotkeys}\n\n" +
+            "They may already be used by Windows or another app. Open Settings to bind new hotkeys.",
+            "Hotkeys Disabled"
+        );
     }
 
     private bool TryBeginInitialSettingsLoad()

--- a/tests/WallpaperSwitcher.Core.Tests/GlobalHotkey/HotkeyServiceTests.cs
+++ b/tests/WallpaperSwitcher.Core.Tests/GlobalHotkey/HotkeyServiceTests.cs
@@ -178,6 +178,7 @@ public class HotkeyServiceTests
     {
         var storage = new FakeHotkeyStorage
         {
+            Exists = true,
             Hotkeys =
             [
                 new HotkeyInfo
@@ -207,6 +208,7 @@ public class HotkeyServiceTests
     {
         var storage = new FakeHotkeyStorage
         {
+            Exists = true,
             Hotkeys =
             [
                 new HotkeyInfo
@@ -232,16 +234,110 @@ public class HotkeyServiceTests
     }
 
     [Test]
+    public void LoadHotkeys_WhenPersistedHotkeyRegistrationFails_SkipsFailureAndSavesSuccessfulHotkeys()
+    {
+        var registrar = new FakeHotkeyRegistrar();
+        registrar.RegisterResults.Enqueue(true);
+        registrar.RegisterResults.Enqueue(false);
+        var storage = new FakeHotkeyStorage
+        {
+            Exists = true,
+            Hotkeys =
+            [
+                new HotkeyInfo
+                {
+                    Id = 1000,
+                    Hotkey = new Hotkey(ModifierKeys.Ctrl | ModifierKeys.Alt, VirtualKeys.A),
+                    Name = "Folder"
+                },
+                new HotkeyInfo
+                {
+                    Id = 1001,
+                    Hotkey = new Hotkey(ModifierKeys.Ctrl | ModifierKeys.Alt, VirtualKeys.W),
+                    Name = Default.NextWallpaperHotkeyName
+                }
+            ]
+        };
+        var service = CreateService(registrar, storage);
+
+        var result = service.LoadHotkeys();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.HasFailures, Is.True);
+            Assert.That(result.Failures, Has.Exactly(1).Items);
+            Assert.That(result.Failures[0].HotkeyInfo.Name, Is.EqualTo(Default.NextWallpaperHotkeyName));
+            Assert.That(result.Failures[0].HotkeyInfo.Hotkey,
+                Is.EqualTo(new Hotkey(ModifierKeys.Ctrl | ModifierKeys.Alt, VirtualKeys.W)));
+            Assert.That(service.GetRegisteredHotkeys(), Has.Exactly(1).Items);
+            Assert.That(service.GetHotKeyInfoBy(h => h.Name, "Folder"), Is.Not.Null);
+            Assert.That(storage.SaveCount, Is.EqualTo(1));
+            Assert.That(storage.SavedHotkeys, Has.Exactly(1).Items);
+            Assert.That(storage.SavedHotkeys[0].Name, Is.EqualTo("Folder"));
+        }
+    }
+
+    [Test]
+    public async Task LoadHotkeysAsync_WhenPersistedHotkeyRegistrationFails_SkipsFailureAndSavesSuccessfulHotkeys()
+    {
+        var registrar = new FakeHotkeyRegistrar();
+        registrar.RegisterResults.Enqueue(false);
+        var storage = new FakeHotkeyStorage
+        {
+            Exists = true,
+            Hotkeys =
+            [
+                new HotkeyInfo
+                {
+                    Id = 1000,
+                    Hotkey = new Hotkey(ModifierKeys.Ctrl | ModifierKeys.Alt, VirtualKeys.W),
+                    Name = Default.NextWallpaperHotkeyName
+                }
+            ]
+        };
+        var service = CreateService(registrar, storage);
+
+        var result = await service.LoadHotkeysAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.HasFailures, Is.True);
+            Assert.That(result.Failures, Has.Exactly(1).Items);
+            Assert.That(service.GetRegisteredHotkeys(), Is.Empty);
+            Assert.That(storage.SaveCount, Is.EqualTo(1));
+            Assert.That(storage.SavedHotkeys, Is.Empty);
+        }
+    }
+
+    [Test]
+    public void LoadHotkeys_WhenStorageFileExistsButIsEmpty_DoesNotRegisterDefaultHotkey()
+    {
+        var storage = new FakeHotkeyStorage { Exists = true };
+        var service = CreateService(storage: storage);
+
+        var result = service.LoadHotkeys();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.HasFailures, Is.False);
+            Assert.That(service.GetRegisteredHotkeys(), Is.Empty);
+            Assert.That(storage.SaveCount, Is.Zero);
+        }
+    }
+
+    [Test]
     public void LoadHotkeys_WhenStorageIsEmpty_RegistersAndSavesDefaultHotkey()
     {
         var storage = new FakeHotkeyStorage();
         var service = CreateService(storage: storage);
 
-        service.LoadHotkeys();
+        var result = service.LoadHotkeys();
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(result.HasFailures, Is.False);
             Assert.That(service.GetRegisteredHotkeys(), Has.Exactly(1).Items);
+            Assert.That(storage.SaveCount, Is.EqualTo(1));
             Assert.That(storage.SavedHotkeys, Has.Exactly(1).Items);
             Assert.That(storage.SavedHotkeys[0].Name, Is.EqualTo(Default.NextWallpaperHotkeyName));
         }
@@ -253,11 +349,13 @@ public class HotkeyServiceTests
         var storage = new FakeHotkeyStorage();
         var service = CreateService(storage: storage);
 
-        await service.LoadHotkeysAsync();
+        var result = await service.LoadHotkeysAsync();
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(result.HasFailures, Is.False);
             Assert.That(service.GetRegisteredHotkeys(), Has.Exactly(1).Items);
+            Assert.That(storage.SaveCount, Is.EqualTo(1));
             Assert.That(storage.SavedHotkeys, Has.Exactly(1).Items);
             Assert.That(storage.SavedHotkeys[0].Name, Is.EqualTo(Default.NextWallpaperHotkeyName));
         }
@@ -334,9 +432,13 @@ public class HotkeyServiceTests
 
     private sealed class FakeHotkeyStorage : IHotkeyStorage
     {
+        public bool Exists { get; init; }
+
         public List<HotkeyInfo> Hotkeys { get; init; } = [];
 
         public List<HotkeyInfo> SavedHotkeys { get; private set; } = [];
+
+        public int SaveCount { get; private set; }
 
         public Task<IEnumerable<HotkeyInfo>> LoadAsync()
         {
@@ -350,12 +452,14 @@ public class HotkeyServiceTests
 
         public Task SaveAsync(IEnumerable<HotkeyInfo> hotkeys)
         {
+            SaveCount++;
             SavedHotkeys = hotkeys.ToList();
             return Task.CompletedTask;
         }
 
         public void Save(IEnumerable<HotkeyInfo> hotkeys)
         {
+            SaveCount++;
             SavedHotkeys = hotkeys.ToList();
         }
     }

--- a/tests/WallpaperSwitcher.Core.Tests/Persistence/JsonHotkeyStorageTests.cs
+++ b/tests/WallpaperSwitcher.Core.Tests/Persistence/JsonHotkeyStorageTests.cs
@@ -51,6 +51,21 @@ public class JsonHotkeyStorageTests
     }
 
     [Test]
+    public void Exists_WhenFileDoesNotExist_ReturnsFalse()
+    {
+        Assert.That(_jsonHotkeyStorage.Exists, Is.False);
+    }
+
+    [Test]
+    public void Exists_WhenFileExists_ReturnsTrue()
+    {
+        Directory.CreateDirectory(_testDirectory);
+        File.WriteAllText(_testFilePath, "[]");
+
+        Assert.That(_jsonHotkeyStorage.Exists, Is.True);
+    }
+
+    [Test]
     public async Task SaveAsync_WithValidHotkeys_CreatesFileWithCorrectContent()
     {
         var hotkeys = new[]


### PR DESCRIPTION
## Summary

Fixes startup failure when a saved global hotkey cannot be registered by Windows.

Previously, if a user saved a hotkey such as `Ctrl+Alt+W` and Windows or another app later occupied that shortcut, `LoadHotkeysAsync()` threw during startup. The desktop app then showed an error dialog and exited.

This PR makes startup hotkey loading tolerant of registration failures:
- skipped hotkeys are reported back as non-fatal load failures
- the app continues launching
- the user gets a warning listing disabled hotkeys
- only successfully registered hotkeys are saved back to `hotkeys.json`

## Changes

- Add `HotkeyLoadResult` and `HotkeyLoadFailure`
- Make `LoadHotkeys()` / `LoadHotkeysAsync()` return load results instead of failing the whole startup path
- Skip persisted hotkeys that fail to register during startup
- Persist successful hotkeys after skipped failures so invalid/conflicting bindings are cleared
- Add `IHotkeyStorage.Exists` to distinguish first launch from an existing empty config
- Show a warning in the desktop app when saved hotkeys are disabled
- Add tests for failed startup registration and empty existing hotkey storage

## Testing

- [x] `dotnet test`
- [x] `dotnet build`

## Fixes

Fixes #6 